### PR TITLE
Develop

### DIFF
--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -1,8 +1,37 @@
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; Interactively evaluate SPARQL
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; sparql-mode.el --- Interactively evaluate SPARQL
+
+;; Copyright (C) 2011  Craig Andera
+;; Copyright (C) 2013  Marcus Nitzschke
+
+;; Author: Craig Andera <candera@wangdera.com>
+;; Version: 0.0.1
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Usage:
+
+;; Add to your emacs config:
+
+;;  (add-to-list 'load-path "/path/to/sparql-mode-dir")
+;;  (autoload 'sparql-mode "sparql-mode.el"
+;;   "Major mode for editing SPARQL files" t)
+;;  (add-to-list 'auto-mode-alist '("\\.sparql$" . sparql-mode))
+
 
 (defgroup sparql nil
   "Major mode for editing and evaluating SPARQL queries."
@@ -131,3 +160,5 @@ If the region is not active, use the whole buffer."
   (define-key sparql-mode-map (kbd "C-c C-x") 'sparql-query-region))
 
 (provide 'sparql-mode)
+
+;;; sparql-mode.el ends here


### PR DESCRIPTION
This pull request contains four changes:
- added the missing `UNION` keyword
- added an ELPA conform header including license (I hope you agree with that)
- `sparql-default-base-url` is now a `defcustom`
- changed the format behaviour
  - the hardcoded csv format is now replaced by a variable `sparql-default-format` which is "csv"
  - the variable `sparql-prompt-format` indicates whether the user should be prompted for the format on each query evaluation. default is `nil`
    - if this is `t` the user gets prompted and each selection of a format is the default-value of the next prompt
