### PR TITLE
Feature: Add format options and send query as form data as per spec

### DIFF
--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -42,10 +42,15 @@
   :group 'sparql
   :type 'string)
 
-(defcustom sparql-default-format "csv"
+(defcustom sparql-default-format "text/csv"
   "The default format of the returned results."
   :group 'sparql
-  :type 'string)
+  :type '(choice
+          (const :tag "Comma separated values" "text/csv")
+          (const :tag "Tab separated values" "text/tab-separated-values")
+          (const :tag "JSON" "application/sparql-results+json")
+          (const :tag "SPARQL XML" "application/sparql-results+xml")
+          (string :tag "Custom")))
 
 (defcustom sparql-prompt-format nil
   "Non-nil means prompt user for requested format on each query evaluation."


### PR DESCRIPTION
The user can now select (via customize) which sparql output format should be the default. Options include csv, tsv, json, sparql-results xml, and a custom string.

Also includes a very small cleanup of the sparql-get-format function. 

Does not include any function renaming or messing about with whitespace.
