### PR TITLE
Fixed a bug in function sparql-handle-results

### DIFF
--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -143,7 +143,7 @@ SPARQL query."
       (error "URL '%s' is not accessible" endpoint-url))
     (with-current-buffer sparql-results-buffer
       (let ((buffer-read-only nil))
-        (if (<= 200 response 299)
+        (if (and (<= 200 response) (>= 299 response))
             (url-insert results-buffer)
           (insert results-buffer))
         (setq mode-name "SPARQL[finished]")))))


### PR DESCRIPTION
Hi,

in function sparql-handle-results, when checking the HTTP response code, it should be something like
(if (and (<= 200 response) (>= 299 response))
instead of 
(if (<= 200 response 299)
because (>= ...) takes exactly 2 arguments.

After fixing I was able to send queries to a fuseki server and read the results in a new buffer.

sparql-mode was exactly the thing I was looking for. Great! Thanks!

Regards
Christian