### PR TITLE
Fix wrong argument passing

### DIFF
--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -177,7 +177,7 @@ If the region is not active, use the whole buffer."
          (end (if (region-active-p) (region-end) (point-max)))
          (query (buffer-substring beg end)))
     (with-current-buffer (get-buffer-create (format "*SPARQL: %s*" (buffer-name)))
-      (sparql-result-mode t)
+      (sparql-result-mode)
       (let ((buffer-read-only nil))
 	(delete-region (point-min) (point-max))))
     (sparql-execute-query query)


### PR DESCRIPTION
A major mode sparql-result-mode does not take any arguments.

You can get following error by `M-: (sparql-mode t)`.

```
Debugger entered--Lisp error: (wrong-number-of-arguments (lambda nil "Major mode $
\\{sparql-mode-map} 
```
