### PR TITLE
Move company setup out of mode function

### DIFF
--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -325,6 +325,11 @@ keywords."
                                     (split-string (buffer-string) "\n" t))))
     (require-match 'never)))
 
+(eval-after-load 'company
+  '(push 'company-sparql company-backends))
+(eval-after-load 'company-keywords
+  '(push `(sparql-mode . ,sparql--keywords) company-keywords-alist))
+
 (define-derived-mode sparql-result-mode read-only-mode "SPARQL[waiting]"
   "Major mode to hold the result from the SPARQL-queries."
   :group 'sparql-result-mode)
@@ -352,11 +357,7 @@ keywords."
           t   ;; font-lock-keywords-case-fold-search
           ))
   (when (boundp 'auto-complete-mode)
-    (add-to-list 'ac-sources 'ac-source-sparql-mode))
-  (when (boundp 'company-mode)
-    (add-to-list 'company-backends 'company-sparql)
-    (add-to-list 'company-keywords-alist
-                 `(sparql-mode . ,sparql--keywords))))
+    (add-to-list 'ac-sources 'ac-source-sparql-mode)))
 
 (provide 'sparql-mode)
 


### PR DESCRIPTION
https://github.com/ljos/sparql-mode/issues/52

I'm not keen on modifying `company-backends` without asking the user but at least this avoids the problem of `company-keywords-alist` being unbound.

On Emacs 24.4 or older you can use `with-eval-after-load` but it seems you are supporting some older versions.