### PR TITLE
Update ob-sparql.el

### DIFF
--- a/ob-sparql.el
+++ b/ob-sparql.el
@@ -79,7 +79,7 @@ variable."
     (insert body)
     (let ((case-fold-search nil)
 	  (case-replace nil))
-      (dolist (pair (mapcar #'cdr (org-babel-get-header params :var)))
+      (dolist (pair (mapcar #'cdr (org-babel--get-vars params)))
 	(goto-char (point-min))
 	(let ((regexp (concat "[$?]" (regexp-quote (format "%s" (car pair)))))
 	      (replacement (cdr pair)))


### PR DESCRIPTION
org-babel-get-header was removed in 0d000f5 (babel: small change in API, 2015-10-29)