### PR TITLE
Fix ob-sparql bug when CALLing

### DIFF
--- a/ob-sparql.el
+++ b/ob-sparql.el
@@ -79,7 +79,7 @@ variable."
     (insert body)
     (let ((case-fold-search nil)
 	  (case-replace nil))
-      (dolist (pair (mapcar #'cdr (org-babel--get-vars params)))
+      (dolist (pair (org-babel--get-vars params))
 	(goto-char (point-min))
 	(let ((regexp (concat "[$?]" (regexp-quote (format "%s" (car pair)))))
 	      (replacement (cdr pair)))


### PR DESCRIPTION
Fix bug when running example CALL in README `Wrong type argument: listp, "<http://example.com/my-graph>"`