### PR TITLE
Feat: extend indentation

### DIFF
--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -106,6 +106,11 @@ If nil the code below will use query=."
   :type 'hook
   :group 'sparql)
 
+(defcustom sparql-indent-line-regex "\\S-+\\s-+\\S-+;\\s-*$"
+  "Regex used to determine the column to indent to."
+  :type 'string
+  :group 'sparql)
+
 (defvar-local sparql-results-buffer nil)
 (defvar-local sparql-base-url nil)
 (defvar-local sparql-format nil)
@@ -273,7 +278,7 @@ asynchronously."
     (save-excursion
       (forward-line -1)
       (setq indent-column
-            (string-match "\\S-+\\s-+\\S-+;\\s-*$"
+            (string-match sparql-indent-line-regex
                           (thing-at-point 'line))))
     (save-excursion
       (ignore-errors

--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -106,7 +106,7 @@ If nil the code below will use query=."
   :type 'hook
   :group 'sparql)
 
-(defcustom sparql-indent-line-regex "\\S-+\\s-+\\S-+\\s-*;\\s-*$"
+(defcustom sparql-indent-line-regex "\\S-+\\s-+\\S-+\\s-*;\\s-*\\(#.*\\)?$"
   "Regex used to determine the column to indent to."
   :type 'string
   :group 'sparql)

--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -106,7 +106,7 @@ If nil the code below will use query=."
   :type 'hook
   :group 'sparql)
 
-(defcustom sparql-indent-line-regex "\\S-+\\s-+\\S-+\\s-*;\\s-*\\(#.*\\)?$"
+(defcustom sparql-indent-line-regex "\\(\\S-+\\s-*,\\)\\|\\(\\S-+\\s-+\\S-+\\s-*;\\)\\s-*\\(#.*\\)?$"
   "Regex used to determine the column to indent to."
   :type 'string
   :group 'sparql)

--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -106,7 +106,7 @@ If nil the code below will use query=."
   :type 'hook
   :group 'sparql)
 
-(defcustom sparql-indent-line-regex "\\(\\S-+\\s-*,\\)\\|\\(\\S-+\\s-+\\S-+\\s-*;\\)\\s-*\\(#.*\\)?$"
+(defcustom sparql-indent-line-regex "\\(\\(\\S-+\\s-*,\\)\\|\\(\\S-+\\s-+\\S-+\\s-*;\\)\\)\\s-*\\(#.*\\)?$"
   "Regex used to determine the column to indent to."
   :type 'string
   :group 'sparql)

--- a/sparql-mode.el
+++ b/sparql-mode.el
@@ -106,7 +106,7 @@ If nil the code below will use query=."
   :type 'hook
   :group 'sparql)
 
-(defcustom sparql-indent-line-regex "\\S-+\\s-+\\S-+;\\s-*$"
+(defcustom sparql-indent-line-regex "\\S-+\\s-+\\S-+\\s-*;\\s-*$"
   "Regex used to determine the column to indent to."
   :type 'string
   :group 'sparql)


### PR DESCRIPTION
Extends the regex used to set `indent-column` in `sparql-indent-line` such that it covers more situations. Also puts the regex in a customisable variable to avoid it being hardcoded in the function.

- Allow spaces in front of a semicolon as well as a comment after it:
```sparql
?subject ?predicate ?object ; # a comment
         ?otherPredicate ?otherObject .
```
- When previous line ends with a comma, set `indent-column` to where that line's object starts:
``` sparql
?subject ?predicate ?object ,
                    ?otherObject .
```